### PR TITLE
feat: add Canvas Zoom via mouse, move canvas and tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-popover": "^1.1.1",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.2",
+    "@radix-ui/react-tooltip": "^1.1.3",
     "@vercel/analytics": "^1.3.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/src/components/custom/Info.tsx
+++ b/src/components/custom/Info.tsx
@@ -1,7 +1,6 @@
-
 const Info = () => {
   return (
-    <div className="bg-white rounded-lg shadow-lg border p-6 max-w-[80%] mx-auto mb-4">
+    <div className="bg-white rounded-xl shadow-lg border p-6 max-w-[80%] mx-auto mb-4">
       <div className="flex items-center justify-center mb-4">
         <img
           src="/logo.png"
@@ -10,7 +9,9 @@ const Info = () => {
           height={40}
           className="rounded-md mr-2"
         />
-        <h1 className="text-xl md:text-3xl font-bold text-gray-800">Sketchify Me</h1>
+        <h1 className="text-xl md:text-3xl font-bold text-gray-800">
+          Sketchify Me
+        </h1>
       </div>
       <p className="text-center text-gray-600 mb-2 md:mb-3">
         All your data is saved locally in your browser.
@@ -30,8 +31,8 @@ const Info = () => {
         <CommandItem command="Ctrl + Shift + X" action="Clear all" />
       </div>
       <p className="text-center text-gray-600">
-        You can change the color and width of strokes from the palette
-        given at the bottom.
+        You can change the color and width of strokes from the palette given at
+        the bottom.
       </p>
     </div>
   );

--- a/src/components/custom/SketchCanvas.tsx
+++ b/src/components/custom/SketchCanvas.tsx
@@ -44,7 +44,6 @@ const SketchCanvas: React.FC = () => {
     setTextValue(e.target.value);
   };
 
-  //include keyboard shortcut handler hook
   useKeyboardShortcuts(handleCanvasClickOutside, setIsAlertDialogOpen);
 
   const handleCanvasPointerDown = (
@@ -66,15 +65,20 @@ const SketchCanvas: React.FC = () => {
   };
 
   return (
-    <div>
+    <div style={{ overflow: "hidden", width: "100%", height: "100%" }}>
       <canvas
         ref={canvasRef}
         onPointerDown={handleCanvasPointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
+        onTouchStart={(e) => e.preventDefault()}
+        onTouchMove={(e) => e.preventDefault()}
         width={window.innerWidth}
         height={window.innerHeight}
-        style={{ cursor: cursorStyle, touchAction: "none" }}
+        style={{
+          cursor: cursorStyle,
+          touchAction: "none",
+        }}
       />
 
       {isWritingText && (
@@ -85,6 +89,7 @@ const SketchCanvas: React.FC = () => {
           strokeColor={strokeColor}
           textValue={textValue}
           handleTextInput={handleTextInput}
+          scale={scale}
         />
       )}
 

--- a/src/components/custom/TextInput.tsx
+++ b/src/components/custom/TextInput.tsx
@@ -8,6 +8,7 @@ interface TextInputProps {
   strokeColor: string;
   textValue: string;
   handleTextInput: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  scale: number;
 }
 
 const TextInput: React.FC<TextInputProps> = ({
@@ -17,6 +18,7 @@ const TextInput: React.FC<TextInputProps> = ({
   strokeColor,
   textValue,
   handleTextInput,
+  scale,
 }) => {
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -34,14 +36,16 @@ const TextInput: React.FC<TextInputProps> = ({
     <Textarea
       style={{
         position: "absolute",
-        left: textBoxPosition.x + panOffset.x,
-        top: textBoxPosition.y + panOffset.y,
-        fontSize: "16px",
-        width: "200px",
-        height: "50px",
+        left: (textBoxPosition.x + panOffset.x) * scale,
+        top: (textBoxPosition.y + panOffset.y) * scale,
+        fontSize: `${16 * scale}px`,
+        width: `${200 * scale}px`,
+        height: `${50 * scale}px`,
         zIndex: 10,
         border: "none",
         color: strokeColor,
+        transform: `scale(${1 / scale})`,
+        transformOrigin: "top left",
       }}
       ref={textAreaRef}
       value={textValue}

--- a/src/components/custom/Toolbar.tsx
+++ b/src/components/custom/Toolbar.tsx
@@ -79,8 +79,9 @@ const ModeButton: React.FC<{
           variant={isActive ? "default" : "outline"}
           onClick={onClick}
           disabled={config.disabled}
+          className="rounded-xl border-none shadow-none h-10"
         >
-          <config.icon className="md:w-4 w-3 md:h-4 h-3 mr-[2px] md:mr-1 bg-inherit" />
+          <config.icon className="w-4 h-4 mr-[2px] md:mr-1 bg-inherit" />
           <span className="hidden md:inline text-sm -mb-3">
             {config.shortcut}
           </span>
@@ -145,8 +146,8 @@ const Toolbar: React.FC = () => {
   }, [handleModeChange]);
 
   return (
-    <nav className="md:bg-white py-2 md:px-4 md:rounded-md md:border mt-2 md:shadow-md z-50">
-      <ul className="space-x-2 md:space-x-2 md:flex">
+    <nav className="md:bg-white py-2 md:px-4 md:rounded-xl md:border mt-2 md:shadow-md z-50">
+      <ul className="space-x-2 md:space-x-2 flex">
         {modeConfigs.map((config) => (
           <li key={config.mode}>
             <ModeButton
@@ -160,7 +161,11 @@ const Toolbar: React.FC = () => {
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button variant="outline" onClick={handleDownload}>
+                <Button
+                  variant="outline"
+                  onClick={handleDownload}
+                  className="rounded-xl border-none shadow-none h-10"
+                >
                   <Download className="md:w-4 w-3 md:h-4 h-3 mr-[2px] md:mr-1 bg-inherit" />
                 </Button>
               </TooltipTrigger>

--- a/src/components/custom/Toolbar.tsx
+++ b/src/components/custom/Toolbar.tsx
@@ -1,3 +1,4 @@
+import React, { useCallback, useEffect } from "react";
 import { useStrokesStore } from "@/store/strokesStore";
 import { Mode, ModeEnum } from "@/lib/utils";
 import {
@@ -7,46 +8,119 @@ import {
   Move,
   MousePointer,
   Download,
+  LucideIcon,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
-const Toolbar = () => {
+interface ModeConfig {
+  mode: Mode;
+  icon: LucideIcon;
+  cursorStyle: string;
+  label: string;
+  shortcut: string;
+  disabled?: boolean;
+}
+
+const modeConfigs: ModeConfig[] = [
+  {
+    mode: ModeEnum.DRAW,
+    icon: Pencil,
+    cursorStyle: "crosshair",
+    label: "Draw",
+    shortcut: "1",
+  },
+  {
+    mode: ModeEnum.WRITE,
+    icon: Type,
+    cursorStyle: "text",
+    label: "Write",
+    shortcut: "2",
+    disabled: true,
+  },
+  {
+    mode: ModeEnum.ERASE,
+    icon: Eraser,
+    cursorStyle: "pointer",
+    label: "Erase",
+    shortcut: "3",
+  },
+  {
+    mode: ModeEnum.SCROLL,
+    icon: Move,
+    cursorStyle: "grab",
+    label: "Move",
+    shortcut: "4",
+  },
+  {
+    mode: ModeEnum.CURSOR,
+    icon: MousePointer,
+    cursorStyle: "default",
+    label: "Select",
+    shortcut: "5",
+  },
+];
+
+const ModeButton: React.FC<{
+  config: ModeConfig;
+  isActive: boolean;
+  onClick: () => void;
+}> = ({ config, isActive, onClick }) => (
+  <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant={isActive ? "default" : "outline"}
+          onClick={onClick}
+          disabled={config.disabled}
+        >
+          <config.icon className="md:w-4 w-3 md:h-4 h-3 mr-[2px] md:mr-1 bg-inherit" />
+          <span className="hidden md:inline text-sm -mb-3">
+            {config.shortcut}
+          </span>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>
+          {config.label} (Press {config.shortcut})
+        </p>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);
+
+const Toolbar: React.FC = () => {
   const { updateMode, mode, updateCursorStyle, downloadImage } =
     useStrokesStore();
   const { toast } = useToast();
 
-  const handleModeChange = (newMode: Mode) => {
-    const activeElement = document.activeElement;
-    if (activeElement?.tagName === "TEXTAREA") {
-      return;
-    }
-    if (newMode === ModeEnum.SCROLL) {
-      updateMode(ModeEnum.SCROLL);
-      updateCursorStyle("grab");
-    } else if (newMode === ModeEnum.DRAW) {
-      updateMode(ModeEnum.DRAW);
-      updateCursorStyle("crosshair");
-    } else if (newMode === ModeEnum.SQUARE) {
-      updateMode(ModeEnum.SQUARE);
-      updateCursorStyle("crosshair");
-    } else if (newMode === ModeEnum.CURSOR) {
-      updateMode(ModeEnum.CURSOR);
-      updateCursorStyle("default");
-    } else if (newMode === ModeEnum.ARROW) {
-      updateMode(ModeEnum.ARROW);
-      updateCursorStyle("crosshair");
-    } else if (newMode === ModeEnum.LINE) {
-      updateMode(ModeEnum.LINE);
-      updateCursorStyle("crosshair");
-    } else if (newMode === ModeEnum.WRITE) {
-      updateMode(ModeEnum.WRITE);
-      updateCursorStyle("text");
-    } else if (newMode === ModeEnum.ERASE) {
-      updateMode(ModeEnum.ERASE);
-      updateCursorStyle("pointer");
-    }
-  };
+  const handleModeChange = useCallback(
+    (newMode: Mode) => {
+      const activeElement = document.activeElement;
+      if (activeElement?.tagName === "TEXTAREA") return;
+
+      const config = modeConfigs.find((c) => c.mode === newMode);
+      if (config) {
+        updateMode(config.mode);
+        updateCursorStyle(config.cursorStyle);
+      }
+
+      if (newMode === ModeEnum.WRITE) {
+        toast({
+          variant: "destructive",
+          title: "Text mode is coming soon!",
+          duration: 1000,
+        });
+      }
+    },
+    [updateMode, updateCursorStyle, toast]
+  );
 
   const handleDownload = () => {
     downloadImage((message: string) =>
@@ -57,60 +131,47 @@ const Toolbar = () => {
       })
     );
   };
-  return (
-    <div className="md:bg-white py-2 md:px-4 md:rounded-md md:border mt-2 md:shadow-md z-50">
-      <div className="space-x-2 md:space-x-2 md:flex">
-          <Button
-            variant={mode === ModeEnum.DRAW ? "default" : "outline"}
-            onClick={() => handleModeChange(ModeEnum.DRAW)}
-          >
-            <Pencil className="md:w-4 w-3 md:h-4 h-3 mr-[2px] md:mr-1 bg-inherit" />
-            <span className="hidden md:inline text-sm -mb-3">1</span>
-          </Button>
-          <Button
-            variant={mode === ModeEnum.WRITE ? "default" : "outline"}
-            // onClick={() => handleModeChange(ModeEnum.WRITE)}
-            onClick={() => {
-              toast({
-                variant: "destructive",
-                title: "Text mode is coming soon!",
-                duration: 1000,
-              });
-            }}
-          >
-            <Type className="md:w-4 w-3 md:h-4 h-3 mr-[2px] md:mr-1 bg-inherit" />
-            <span className="hidden md:inline text-sm -mb-3">2</span>
-          </Button>
-          <Button
-            variant={mode === ModeEnum.ERASE ? "default" : "outline"}
-            onClick={() => handleModeChange(ModeEnum.ERASE)}
-          >
-            <Eraser className="md:w-4 w-3 md:h-4 h-3 mr-[2px] md:mr-1 bg-inherit" />
-            <span className="hidden md:inline text-sm -mb-3">3</span>
-          </Button>
-          <Button
-            variant={mode === ModeEnum.SCROLL ? "default" : "outline"}
-            onClick={() => handleModeChange(ModeEnum.SCROLL)}
-          >
-            <Move className="md:w-4 w-3 md:h-4 h-3 mr-[2px] md:mr-1 bg-inherit" />
-            <span className="hidden md:inline text-sm -mb-3">4</span>
-          </Button>
-          <Button
-            variant={mode === ModeEnum.CURSOR ? "default" : "outline"}
-            onClick={() => handleModeChange(ModeEnum.CURSOR)}
-          >
-            <MousePointer className="md:w-4 w-3 md:h-4 h-3 mr-[2px] md:mr-1 bg-inherit" />
-            <span className="hidden md:inline text-sm -mb-3">5</span>
-          </Button>
 
-          <Button
-            variant="outline"
-            onClick={handleDownload} // Trigger the download on click
-          >
-            <Download className="md:w-4 w-3 md:h-4 h-3 mr-[2px] md:mr-1 bg-inherit" />
-          </Button>
-        </div>
-    </div>
+  useEffect(() => {
+    const handleKeyPress = (event: KeyboardEvent) => {
+      const config = modeConfigs.find((c) => c.shortcut === event.key);
+      if (config && !config.disabled) {
+        handleModeChange(config.mode);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyPress);
+    return () => window.removeEventListener("keydown", handleKeyPress);
+  }, [handleModeChange]);
+
+  return (
+    <nav className="md:bg-white py-2 md:px-4 md:rounded-md md:border mt-2 md:shadow-md z-50">
+      <ul className="space-x-2 md:space-x-2 md:flex">
+        {modeConfigs.map((config) => (
+          <li key={config.mode}>
+            <ModeButton
+              config={config}
+              isActive={mode === config.mode}
+              onClick={() => handleModeChange(config.mode)}
+            />
+          </li>
+        ))}
+        <li>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" onClick={handleDownload}>
+                  <Download className="md:w-4 w-3 md:h-4 h-3 mr-[2px] md:mr-1 bg-inherit" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Download Image</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </li>
+      </ul>
+    </nav>
   );
 };
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,11 +1,11 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-950 disabled:pointer-events-none disabled:opacity-50 dark:focus-visible:ring-zinc-300",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-zinc-950 disabled:pointer-events-none disabled:opacity-50 dark:focus-visible:ring-zinc-300",
   {
     variants: {
       variant: {
@@ -17,7 +17,8 @@ const buttonVariants = cva(
           "border border-zinc-200 bg-white shadow-sm hover:bg-zinc-100 hover:text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:hover:bg-zinc-800 dark:hover:text-zinc-50",
         secondary:
           "bg-zinc-100 text-zinc-900 shadow-sm hover:bg-zinc-100/80 dark:bg-zinc-800 dark:text-zinc-50 dark:hover:bg-zinc-800/80",
-        ghost: "hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-50",
+        ghost:
+          "hover:bg-zinc-100 hover:text-zinc-900 dark:hover:bg-zinc-800 dark:hover:text-zinc-50",
         link: "text-zinc-900 underline-offset-4 hover:underline dark:text-zinc-50",
       },
       size: {
@@ -32,26 +33,26 @@ const buttonVariants = cva(
       size: "default",
     },
   }
-)
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : "button";
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
-    )
+    );
   }
-)
-Button.displayName = "Button"
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 overflow-hidden rounded-md bg-zinc-900 px-3 py-1.5 text-xs text-zinc-50 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:bg-zinc-50 dark:text-zinc-900",
+      className
+    )}
+    {...props}
+  />
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/hooks/useCanvas.ts
+++ b/src/hooks/useCanvas.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Point, ModeEnum, options } from "@/lib/utils";
 import { useStrokesStore } from "@/store/strokesStore";
 import { getStroke } from "perfect-freehand";
@@ -8,6 +8,9 @@ export const useCanvas = () => {
   const [points, setPoints] = useState<Point[]>([]);
   const [isPanning, setIsPanning] = useState(false);
   const [startPan, setStartPan] = useState({ x: 0, y: 0 });
+  const [lastTouchDistance, setLastTouchDistance] = useState<number | null>(
+    null
+  );
 
   const {
     mode,
@@ -20,6 +23,7 @@ export const useCanvas = () => {
     addStroke,
     eraseStroke,
     updatePanOffset,
+    updateScale,
     canvasRef,
   } = useStrokesStore((state) => state);
 
@@ -28,42 +32,51 @@ export const useCanvas = () => {
     options.end.taper = strokeTaper;
   }, [strokeWidth, strokeTaper]);
 
-  const handlePointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
+  const getAdjustedCoordinates = useCallback(
+    (clientX: number, clientY: number) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return { x: 0, y: 0 };
 
-    const rect = canvas.getBoundingClientRect();
-    const x = (e.clientX - rect.left - panOffset.x) / scale;
-    const y = (e.clientY - rect.top - panOffset.y) / scale;
-
-    if (mode === ModeEnum.SCROLL) {
-      setIsPanning(true);
-      setStartPan({ x: e.clientX - panOffset.x, y: e.clientY - panOffset.y });
-    } else {
-      setPoints([{ x, y, pressure: e.pressure }]);
-    }
-  };
-
-  const handlePointerMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
-    if (mode === ModeEnum.SCROLL && isPanning) {
-      updatePanOffset({
-        x: e.clientX - startPan.x,
-        y: e.clientY - startPan.y,
-      });
-      return;
-    }
-
-    if (e.buttons !== 1) return;
-    const canvas = canvasRef.current;
-    if (canvas) {
       const rect = canvas.getBoundingClientRect();
-      const x = (e.clientX - rect.left - panOffset.x) / scale;
-      const y = (e.clientY - rect.top - panOffset.y) / scale;
-      setPoints((prev) => [...prev, { x, y, pressure: e.pressure }]);
-    }
-  };
+      const x = (clientX - rect.left - panOffset.x) / scale;
+      const y = (clientY - rect.top - panOffset.y) / scale;
+      return { x, y };
+    },
+    [canvasRef, panOffset, scale]
+  );
 
-  const handlePointerUp = () => {
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      const { x, y } = getAdjustedCoordinates(e.clientX, e.clientY);
+
+      if (mode === ModeEnum.SCROLL) {
+        setIsPanning(true);
+        setStartPan({ x: e.clientX - panOffset.x, y: e.clientY - panOffset.y });
+      } else {
+        setPoints([{ x, y, pressure: e.pressure }]);
+      }
+    },
+    [mode, panOffset, getAdjustedCoordinates]
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      if (mode === ModeEnum.SCROLL && isPanning) {
+        updatePanOffset({
+          x: e.clientX - startPan.x,
+          y: e.clientY - startPan.y,
+        });
+        return;
+      }
+
+      if (e.buttons !== 1) return;
+      const { x, y } = getAdjustedCoordinates(e.clientX, e.clientY);
+      setPoints((prev) => [...prev, { x, y, pressure: e.pressure }]);
+    },
+    [mode, isPanning, startPan, updatePanOffset, getAdjustedCoordinates]
+  );
+
+  const handlePointerUp = useCallback(() => {
     if (mode === ModeEnum.SCROLL) {
       setIsPanning(false);
       return;
@@ -87,42 +100,167 @@ export const useCanvas = () => {
       });
     }
     setPoints([]);
-  };
+  }, [mode, points, strokeColor, addStroke, eraseStroke]);
 
-  const drawStrokesOnCanvas = (ctx: CanvasRenderingContext2D) => {
-    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
-    ctx.save();
-    ctx.scale(scale, scale);
-    ctx.translate(panOffset.x, panOffset.y);
+  const handleWheel = useCallback(
+    (e: WheelEvent) => {
+      e.preventDefault();
 
-    strokes.forEach((stroke) => {
-      if (stroke.type === "draw") {
-        const path = new Path2D(stroke.path);
-        ctx.fillStyle = stroke.color;
-        ctx.fill(path);
-      } else if (stroke.type === "text") {
-        ctx.font = `${stroke.fontSize}px ${stroke.fontFamily}`;
-        ctx.fillStyle = stroke.color;
-        ctx.textBaseline = "top";
-        ctx.fillText(stroke.text!, stroke.position!.x, stroke.position!.y);
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      const rect = canvas.getBoundingClientRect();
+      const mouseX = e.clientX - rect.left;
+      const mouseY = e.clientY - rect.top;
+
+      if (e.ctrlKey) {
+        // Zooming
+        const delta = e.deltaY * -0.01;
+        const newScale = Math.min(Math.max(scale + delta, 0.1), 5);
+        const scaleFactor = newScale / scale;
+
+        const newPanOffset = {
+          x: mouseX - (mouseX - panOffset.x) * scaleFactor,
+          y: mouseY - (mouseY - panOffset.y) * scaleFactor,
+        };
+
+        updateScale(newScale);
+        updatePanOffset(newPanOffset);
+      } else {
+        // Panning
+        updatePanOffset({
+          x: panOffset.x - e.deltaX,
+          y: panOffset.y - e.deltaY,
+        });
       }
-    });
+    },
+    [scale, panOffset, updateScale, updatePanOffset, canvasRef]
+  );
 
-    if (points.length > 0 && mode === ModeEnum.DRAW) {
-      const path = new Path2D(
-        getSvgPathFromStroke(
-          getStroke(
-            points.map((p) => [p.x, p.y, p.pressure]),
-            { size: strokeWidth }
-          )
-        )
+  const handleTouchStart = useCallback((e: TouchEvent) => {
+    if (e.touches.length === 2) {
+      const touch1 = e.touches[0];
+      const touch2 = e.touches[1];
+      const distance = Math.hypot(
+        touch1.clientX - touch2.clientX,
+        touch1.clientY - touch2.clientY
       );
-      ctx.fillStyle = strokeColor;
-      ctx.fill(path);
+      setLastTouchDistance(distance);
     }
+  }, []);
 
-    ctx.restore();
-  };
+  const handleTouchMove = useCallback(
+    (e: TouchEvent) => {
+      e.preventDefault();
+
+      if (e.touches.length === 2) {
+        const touch1 = e.touches[0];
+        const touch2 = e.touches[1];
+
+        // Handle panning
+        const centerX = (touch1.clientX + touch2.clientX) / 2;
+        const centerY = (touch1.clientY + touch2.clientY) / 2;
+
+        if (startPan.x !== 0 || startPan.y !== 0) {
+          const deltaX = centerX - startPan.x;
+          const deltaY = centerY - startPan.y;
+          updatePanOffset({
+            x: panOffset.x + deltaX,
+            y: panOffset.y + deltaY,
+          });
+        }
+
+        setStartPan({ x: centerX, y: centerY });
+
+        // Handle zooming
+        const distance = Math.hypot(
+          touch1.clientX - touch2.clientX,
+          touch1.clientY - touch2.clientY
+        );
+        if (lastTouchDistance !== null) {
+          const delta = (distance - lastTouchDistance) * 0.01;
+          const newScale = Math.min(Math.max(scale + delta, 0.1), 5);
+          updateScale(newScale);
+        }
+        setLastTouchDistance(distance);
+      }
+    },
+    [
+      startPan,
+      panOffset,
+      scale,
+      lastTouchDistance,
+      updatePanOffset,
+      updateScale,
+    ]
+  );
+
+  const handleTouchEnd = useCallback(() => {
+    setLastTouchDistance(null);
+    setStartPan({ x: 0, y: 0 });
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (canvas) {
+      canvas.addEventListener("wheel", handleWheel, { passive: false });
+      canvas.addEventListener("touchstart", handleTouchStart);
+      canvas.addEventListener("touchmove", handleTouchMove, { passive: false });
+      canvas.addEventListener("touchend", handleTouchEnd);
+    }
+    return () => {
+      if (canvas) {
+        canvas.removeEventListener("wheel", handleWheel);
+        canvas.removeEventListener("touchstart", handleTouchStart);
+        canvas.removeEventListener("touchmove", handleTouchMove);
+        canvas.removeEventListener("touchend", handleTouchEnd);
+      }
+    };
+  }, [
+    canvasRef,
+    handleWheel,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+  ]);
+
+  const drawStrokesOnCanvas = useCallback(
+    (ctx: CanvasRenderingContext2D) => {
+      ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+      ctx.save();
+      ctx.translate(panOffset.x, panOffset.y);
+      ctx.scale(scale, scale);
+
+      strokes.forEach((stroke) => {
+        if (stroke.type === "draw") {
+          const path = new Path2D(stroke.path);
+          ctx.fillStyle = stroke.color;
+          ctx.fill(path);
+        } else if (stroke.type === "text") {
+          ctx.font = `${stroke.fontSize}px ${stroke.fontFamily}`;
+          ctx.fillStyle = stroke.color;
+          ctx.textBaseline = "top";
+          ctx.fillText(stroke.text!, stroke.position!.x, stroke.position!.y);
+        }
+      });
+
+      if (points.length > 0 && mode === ModeEnum.DRAW) {
+        const path = new Path2D(
+          getSvgPathFromStroke(
+            getStroke(
+              points.map((p) => [p.x, p.y, p.pressure]),
+              { size: strokeWidth }
+            )
+          )
+        );
+        ctx.fillStyle = strokeColor;
+        ctx.fill(path);
+      }
+
+      ctx.restore();
+    },
+    [strokes, points, panOffset, scale, mode, strokeColor, strokeWidth]
+  );
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -132,7 +270,7 @@ export const useCanvas = () => {
         drawStrokesOnCanvas(ctx);
       }
     }
-  }, [strokes, points, panOffset, scale]);
+  }, [strokes, points, panOffset, scale, drawStrokesOnCanvas]);
 
   return {
     canvasRef,

--- a/src/store/strokesStore.ts
+++ b/src/store/strokesStore.ts
@@ -20,6 +20,7 @@ interface StrokesState {
   scale: number;
   panOffset: { x: number; y: number };
   canvasRef: React.RefObject<HTMLCanvasElement>;
+
   updateCursorStyle: (cursorStyle: string) => void;
   updateMode: (mode: Mode) => void;
   addStroke: (newStroke: Stroke) => void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -798,6 +798,24 @@
     "@radix-ui/react-use-layout-effect" "1.1.0"
     "@radix-ui/react-visually-hidden" "1.1.0"
 
+"@radix-ui/react-tooltip@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.1.3.tgz#4250b14723f2d8477e7a3d0526c169f91d1f2f74"
+  integrity sha512-Z4w1FIS0BqVFI2c1jZvb/uDVJijJjJ2ZMuPV81oVgTZ7g3BZxobplnMVvXtFWgtozdvYJ+MFWtwkM5S2HnAong==
+  dependencies:
+    "@radix-ui/primitive" "1.1.0"
+    "@radix-ui/react-compose-refs" "1.1.0"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-dismissable-layer" "1.1.1"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-popper" "1.2.0"
+    "@radix-ui/react-portal" "1.1.2"
+    "@radix-ui/react-presence" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-slot" "1.1.0"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    "@radix-ui/react-visually-hidden" "1.1.0"
+
 "@radix-ui/react-use-callback-ref@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz#bce938ca413675bc937944b0d01ef6f4a6dc5bf1"


### PR DESCRIPTION
## Implement Canvas Zoom, Pan, and Toolbar Tooltips

Features implemented:
- Zoom in/out functionality using mousepad centered on mouse position (Ctrl/Cmd + mousewheel to zoom in/out or use zoom gesture in mouse)
- Canvas panning in all directions using mouse and touchpad gestures (Use two-finger gesture on touchpad to pan in any direction)
- Tooltips for toolbar items showing function and keyboard shortcut

Implementation details:
• Added handleWheel function in useCanvas hook to manage zoom and pan events
• Introduced scale and panOffset state in strokesStore to track zoom level and canvas position
• Updated SketchCanvas component to apply zoom and pan transformations to the canvas
• Modified Toolbar component to include Shadcn UI Tooltip components for each button
• Adjusted drawing and erasing functions to work correctly with zoom and pan
